### PR TITLE
Add Japanese keyboard (JIS) layout

### DIFF
--- a/assets/keyboards/qwerty_ja.ini
+++ b/assets/keyboards/qwerty_ja.ini
@@ -235,9 +235,9 @@ Label=^##L\nへ##R
 String=^
 
 [Key_Base_Row_2_ID_13]
-Type=String
+Type=VirtualKey
 Label=￥##L\n
-String=\
+KeyCode=220
 
 [Key_Base_Row_2_ID_14]
 Type=VirtualKey
@@ -678,7 +678,7 @@ KeyCode=28
 Type=VirtualKey
 Width=125
 Label=カタカナ\nひらがな
-KeyCode=21
+KeyCode=240
 
 [Key_Base_Row_6_ID_7]
 Type=VirtualKeyToggle


### PR DESCRIPTION
Hello!
I've added a new keyboard layout for Japanese users.
This layout includes a kanji key, which enables smoother switching between Romaji input and alphabet input.
The mechanism involves sending `VK_KANJI` to toggle the IME state.
This keyboard layout adheres to the JIS standard.
<img width="1203" height="366" alt="image" src="https://github.com/user-attachments/assets/b550cc31-8e21-41a1-b476-60ff5721c97c" />
